### PR TITLE
Add Jugos extra option with explicit add/remove labels

### DIFF
--- a/this1
+++ b/this1
@@ -216,6 +216,16 @@
                         <button class="agregar">Add</button>
                     </div>
                 </div>
+                <div class="item" data-name="Jugos" data-price="1.00">
+                    <span class="description">Jugos</span>
+                    <span class="price">$1.00</span>
+                    <div class="controls">
+                        <button class="minus">- Remove</button>
+                        <span class="quantity">0</span>
+                        <button class="plus">+ Add</button>
+                        <button class="agregar">Add</button>
+                    </div>
+                </div>
             </div>
         </div>
         <div class="resumen">


### PR DESCRIPTION
## Summary
- add a Jugos extra item priced at $1.00 to the Extras section
- display clearer “+ Add” and “- Remove” controls on the new Jugos entry while preserving existing cart behaviour

## Testing
- no automated tests were run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68cd96a912e8832bb3a8e77e27dbbee3