### PR TITLE
Improve light theme contrast

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,10 +7,16 @@
     :root{
       --fg:#e8eef6; --card:#161a2b; --line:#2b2f40; --muted:#a9b3c3;
       --op1:#7aa8ff; --op2:#22c3a6; --op3:#ff8ab3; --op4:#c466ff; --ex:#c3b5ff;
+      --bg-gradient:linear-gradient(180deg,#0e1324,#0b1720,#151a2e);
+      --surface-soft:rgba(255,255,255,.02);
+      --surface-hover:rgba(255,255,255,.05);
+      --surface-softer:rgba(255,255,255,.03);
+      --ex-price-bg:rgba(255,255,255,.05);
+      --divider:rgba(255,255,255,.06);
       --radius:14px; --gap:1rem; --pad:1rem;
     }
     *{box-sizing:border-box}
-    html,body{margin:0;padding:0;font-family:Inter,system-ui,Segoe UI,Roboto,Arial,sans-serif;background:linear-gradient(180deg,#0e1324,#0b1720,#151a2e);color:var(--fg);min-height:100%}
+    html,body{margin:0;padding:0;font-family:Inter,system-ui,Segoe UI,Roboto,Arial,sans-serif;background:var(--bg-gradient);color:var(--fg);min-height:100%}
     body{display:flex;align-items:center;justify-content:center}
     .wrap{width:100%;max-width:1200px;margin:auto;padding:2rem 1rem}
     header{display:flex;justify-content:space-between;align-items:center;margin-bottom:2rem}
@@ -23,8 +29,8 @@
     aside.card{display:flex;flex-direction:column}
     .title{font-size:1.2rem;font-weight:800;margin:0 0 1rem}
     .grid{display:grid;grid-template-columns:repeat(auto-fit,minmax(250px,1fr));gap:var(--gap)}
-    .opt{background:rgba(255,255,255,.02);border:2px solid var(--line);border-radius:var(--radius);padding:1rem;transition:transform .15s ease,background .15s ease}
-    .opt:hover{background:rgba(255,255,255,.05);transform:scale(1.02)}
+    .opt{background:var(--surface-soft);border:2px solid var(--line);border-radius:var(--radius);padding:1rem;transition:transform .15s ease,background .15s ease}
+    .opt:hover{background:var(--surface-hover);transform:scale(1.02)}
     .top{display:flex;align-items:center;gap:.8rem;margin-bottom:.5rem}
     .btn50{width:44px;height:35px;border:none;border-radius:8px;font-weight:900;color:#111}
     .op1{background:var(--op1)} .op2{background:var(--op2)} .op3{background:var(--op3)} .op4{background:var(--op4)}
@@ -33,11 +39,11 @@
     .btn{padding:6px 12px;border:1px solid var(--line);background:transparent;color:var(--fg);font-weight:800;border-radius:10px;cursor:pointer;font-size:13px;white-space:nowrap;transition:background .15s ease,color .15s ease,border-color .15s ease}
     .btn-adding{background:#22c3a6 !important;color:#0b0f18 !important;border-color:#22c3a6 !important}
     .ex-list{display:flex;flex-direction:column;gap:.75rem}
-    .ex-row{display:grid;grid-template-columns:1fr auto;align-items:center;background:rgba(255,255,255,.03);border:1px solid var(--line);border-radius:12px;padding:.75rem 1rem}
+    .ex-row{display:grid;grid-template-columns:1fr auto;align-items:center;background:var(--surface-softer);border:1px solid var(--line);border-radius:12px;padding:.75rem 1rem}
     .ex-left{display:flex;align-items:center;gap:1rem;font-weight:800}
-    .ex-price{font-size:.9rem;padding:.35rem .7rem;border-radius:8px;border:1px dashed var(--line);background:rgba(255,255,255,.05);font-weight:800}
-    .cart{border:1px dashed var(--line);border-radius:var(--radius);padding:1rem;max-height:320px;overflow:auto}
-    .line{display:grid;grid-template-columns:1fr auto auto;gap:.6rem;align-items:center;padding:.6rem 0;border-bottom:1px dotted rgba(255,255,255,.06)}
+    .ex-price{font-size:.9rem;padding:.35rem .7rem;border-radius:8px;border:1px dashed var(--line);background:var(--ex-price-bg);font-weight:800}
+    .cart{border:1px dashed var(--line);border-radius:var(--radius);padding:1rem;max-height:320px;overflow:auto;background:var(--surface-soft)}
+    .line{display:grid;grid-template-columns:1fr auto auto;gap:.6rem;align-items:center;padding:.6rem 0;border-bottom:1px dotted var(--divider)}
     .qtybox{display:flex;align-items:center;gap:.5rem}
     .totals{margin-top:1rem;display:grid;gap:.5rem}
     .totals .row{display:flex;justify-content:space-between}
@@ -50,7 +56,16 @@
     .loader-overlay{position:fixed;inset:0;background:rgba(0,0,0,.6);display:none;align-items:center;justify-content:center;z-index:9999}
     .loader{width:54px;height:54px;border:6px solid rgba(255,255,255,.25);border-top-color:#22c3a6;border-radius:50%;animation:spin .9s linear infinite}
     @keyframes spin{to{transform:rotate(360deg)}}
-    [data-theme="light"] body{background:linear-gradient(135deg,#f3fbf7,#eaf2ff,#ffe9ef)}
+    [data-theme="light"]{
+      --fg:#0f1a2b; --card:#ffffff; --line:#d8dce8; --muted:#5c6d82;
+      --op1:#3f7cff; --op2:#1c9f86; --op3:#ff5d8f; --op4:#8c4bff; --ex:#7560ff;
+      --bg-gradient:linear-gradient(135deg,#f7fbff,#eef3ff,#ffeef3);
+      --surface-soft:rgba(15,30,60,.04);
+      --surface-hover:rgba(15,30,60,.08);
+      --surface-softer:rgba(15,30,60,.06);
+      --ex-price-bg:rgba(15,30,60,.1);
+      --divider:rgba(15,30,60,.15);
+    }
     [data-theme="light"] .btn-adding{background:#22c3a6 !important;color:#0b0f18 !important}
   </style>
 </head>


### PR DESCRIPTION
## Summary
- introduce reusable CSS variables for surface backgrounds, gradients, and dividers
- refresh the light theme palette so the background and cards provide stronger contrast
- update option, extra, and cart surfaces to respect the new theme tokens

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68ce32c9b574832b965f3d59d1fc5ba8