### PR TITLE
Align option card styling

### DIFF
--- a/index.html
+++ b/index.html
@@ -272,13 +272,6 @@
       rem:{ es:'− Quitar',  en:'− Remove' }
     };
 
-    const OPTION_THEME = {
-      op1:'cafe',
-      op2:'chorizo',
-      op3:'huevo',
-      op4:'tortilla'
-    };
-
     const EXTRA_THEME = {
       ex_cafe:'cafe',
       ex_cola:'cola',
@@ -312,8 +305,8 @@
     function buildOptions(){
       const host = $('#opts'); host.innerHTML='';
       OPTIONS.forEach((o,i)=>{
-        const variant = OPTION_THEME[o.id] || 'cafe';
-        const badgeClass = (i % 4) + 1;
+        const variant = 'cafe';
+        const badgeClass = 1;
         const el = document.createElement('article');
         el.className = `card option-card card--${variant}`;
         el.innerHTML = `


### PR DESCRIPTION
## Summary
- make every option card reuse the same cafe themed styling as option 1
- standardize the numbered badge appearance so all options share the primary badge color

## Testing
- no automated tests were run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68ce482cb948832baf1a3a84ab66bd49